### PR TITLE
bug: fix

### DIFF
--- a/others/bircf/Ircserv.cpp
+++ b/others/bircf/Ircserv.cpp
@@ -34,7 +34,6 @@ void	Ircserv::srvCreate(int port) {
   int                 yes = 1;
 
   pe = (struct protoent*)Xv(NULL, getprotobyname("tcp"), (char *)"getprotobyname");
-  // s = X(-1, socket(PF_INET, SOCK_STREAM, pe->p_proto), (char *)"socket");
   s = X(-1, socket(AF_INET, SOCK_STREAM, pe->p_proto), (char *)"socket");
 
   X(-1, setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)), (char *)"setsockopt");
@@ -43,7 +42,6 @@ void	Ircserv::srvCreate(int port) {
   sin.sin_family = AF_INET;
   sin.sin_addr.s_addr = INADDR_ANY;
   sin.sin_port = htons(port);
-  // X(-1, bind(s, (struct sockaddr*)&sin, sizeof(sin)), (char *)"bind");
   X(-1, bind(s, (sockaddr*)&sin, sizeof(sin)), (char *)"bind");
   X(-1, listen(s, 42), (char *)"listen");
 
@@ -89,13 +87,11 @@ void	Ircserv::doSelect() {
     max = urit->first;
   }
 
-  // r = select(max + 1, &fdRead, &fdWrite, NULL, NULL); //&loopInterval); //NULL, 0
-  // r = select(max + 1, &fdRead, &fdWrite, NULL, &selectInterval); //&loopInterval); //NULL, 0
   r = select(max + 1, &fdRead, &fdWrite, NULL, &selectInterval); //&loopInterval); //NULL, 0
 }
 
 void	Ircserv::checkFd() {
-  if (r <= 0) return;
+  if (r < 0) return;
 
   //server
   if (FD_ISSET(ircFd, &fdRead)) {
@@ -109,8 +105,9 @@ void	Ircserv::checkFd() {
   std::map<int, User>::iterator uit = messenger.users().begin();
   time_t now = time(NULL);
   for (; uit != messenger.users().end(); ++uit) {
-    if (uit->second.dead < now || uit->second.quit)
+    if (uit->second.dead < now || uit->second.quit) {
       timeout.push(uit->second);
+    }
     else {
       if (uit->second.alive < now)
         messenger.ping(uit->first);

--- a/others/bircf/Models.hpp
+++ b/others/bircf/Models.hpp
@@ -17,7 +17,7 @@
 // #define TIMEOUT 300
 #define TIMEOUT 300
 // #define WAIT_TIME 30
-#define WAIT_TIME 3000
+#define WAIT_TIME 30
 #define CHANNEL_MEMBER_LIMIT 32
 #define USER_ENGAGED_LIMIT 32
 #define PING_REQUEST "PING :"


### PR DESCRIPTION
telnet 환경에서, quit를 날렸을때, 클라이언트가 금방 죽지 않는 문제를 해결했습니다.

void	Ircserv::checkFd() {
  if (r < 0) return;

부분이 원래는
  if (r <= 0) return;

이었습니다만, timeout을 걸어둔 관계로, r == 0 일 수도 있으므로, = 을 제거했습니다.
그래서, 이제는 quit를 입력하면, 1초만에 telnet client도 종료 가능하게 됩니다.
